### PR TITLE
Allows for larger data columns (totalling about 2mb in size)

### DIFF
--- a/config/all-envs.json
+++ b/config/all-envs.json
@@ -4,8 +4,9 @@
 
 {
   "showStackTraces": true,
-  "logLevel": "debug",
-  "logTarget": "humanizer",
-  "locatorSalt": "CHANGE_ME",
-  "PORT" : 3000
+  "logLevel":        "debug",
+  "logTarget":       "humanizer",
+  "locatorSalt":     "CHANGE_ME",
+  "PORT":            3000,
+  "bodyLimit":       "2mb"
 }

--- a/migrations/20140802203119-expand-text-columns.js
+++ b/migrations/20140802203119-expand-text-columns.js
@@ -1,0 +1,18 @@
+var dbm = require('stex').dbMigrate;
+var type = dbm.dataType;
+
+exports.up = function(db, callback) {
+  db.changeColumn('wallets', 'mainData', { type: type.TEXT, length:16777216 }, function(){
+    db.changeColumn('wallets', 'keychainData', { type: type.TEXT, length:16777216 }, function(){
+      db.changeColumn('wallets', 'recoveryData', { type: type.TEXT, length:16777216 }, callback);
+    });
+  });
+};
+
+exports.down = function(db, callback) {
+  db.changeColumn('wallets', 'mainData', { type: type.TEXT, length:65535 }, function(){
+    db.changeColumn('wallets', 'keychainData', { type: type.TEXT, length:65535 }, function(){
+      db.changeColumn('wallets', 'recoveryData', { type: type.TEXT, length:65535 }, callback);
+    });
+  });
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -22,7 +22,7 @@
     "stex": {
       "version": "0.1.0",
       "from": "git+ssh://git@github.com:stellar/stex.git#master",
-      "resolved": "git+ssh://git@github.com:stellar/stex.git#e8c9b15123e5e65f1209db9eee15a92767ea308b",
+      "resolved": "git+ssh://git@github.com:stellar/stex.git#0fb364237de2df89425021e1b55d9e9c1dee4cdc",
       "dependencies": {
         "bluebird": {
           "version": "2.2.2",

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -31,6 +31,14 @@ var loadFixtures = function() {
   ]);
 }
 
+helpers.makeString = function(size) {
+  var x = "";
+  for(var i = 0; i < size; i++) {
+    x += "a";
+  }
+  return x;
+}
+
 beforeEach(function(done) {
   clearDb()
     .then(loadFixtures)

--- a/test/wallets_test.js
+++ b/test/wallets_test.js
@@ -212,6 +212,21 @@ describe("POST /wallets/update", function() {
 
   it("fails when the provided mainHash doesn't verify the mainData",         badHashTest("mainData"));
   it("fails when the provided keychainHash doesn't verify the keychainData", badHashTest("keychainData"));
+
+  it("succeeds with inputs of 1mb in size", function(done) {
+    var self = this;
+
+    this.params.mainData     = helper.makeString(1 * 1024 * 1024); //1 mb
+    this.params.mainDataHash = hash.sha1(this.params.mainData);
+
+    this.submitWithSuccessTest().end(function() {
+      wallet.get(self.params.id).then(function(w) {
+
+        expect(w.mainData.length).to.equal(self.params.mainData.length);
+      })
+      .finally(done)
+    });
+  });
 });
 
 


### PR DESCRIPTION
This PR primarily does 2 things:
1.  Expands the text columns in wallets to MEDIUMTEXT types (with a max size of ~16mb)
2.  Updates stex to allow customization of the body size limit within express
3.  Sets that limit to 2mb.

This should give us quite a lot of headroom for people with lots of contacts.
