### PR TITLE
Kill stexdev

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,5 +11,5 @@
   "boss": true,
   "eqnull": true,
   "node": true,
-  "predef": [ "conf", "db", "log", "stex", "app", "-Promise" ]
+  "predef": [ "conf", "db", "log", "stex", "app", "-Promise", "before", "beforeEach", "it", "describe", "test", "expect" ]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,8 @@
 var Stex    = require("stex");
-var stexDev = require("stex-dev");
-var gulp    = stexDev.gulp();
-var plugins = stexDev.gulpPlugins();
-var paths   = stexDev.paths;
+var StexDev = require("stex/dev");
+var gulp    = StexDev.gulp();
+var plugins = StexDev.gulpPlugins();
+var paths   = StexDev.paths;
 
 paths.root = __dirname; //HACK: can't think of a better way to expose the app root prior to stex init
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,434 +1,1078 @@
 {
   "name": "stellar-wallet",
   "version": "0.0.1",
+  "npm-shrinkwrap-version": "3.1.8",
   "dependencies": {
     "scrypt-hash": {
       "version": "1.1.8",
-      "from": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.8.tgz",
       "resolved": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.8.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/bindings/-/bindings-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.1.1.tgz"
         },
         "nan": {
           "version": "0.7.0",
-          "from": "https://registry.npmjs.org/nan/-/nan-0.7.0.tgz",
           "resolved": "https://registry.npmjs.org/nan/-/nan-0.7.0.tgz"
         }
       }
     },
     "stex": {
       "version": "0.1.0",
-      "from": "git+https://github.com/stellar/stex.git#master",
-      "resolved": "git+https://github.com/stellar/stex.git#88e32ebe801381b62130852778e87d65db3548ae",
+      "from": "stex@git+https://github.com/stellar/stex.git#5a6d2c5c836b2f010341772c7ccab2479dcb37ee",
+      "resolved": "git+https://github.com/stellar/stex.git#5a6d2c5c836b2f010341772c7ccab2479dcb37ee",
       "dependencies": {
         "bluebird": {
-          "version": "2.3.0",
-          "from": "bluebird@^2.2.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.3.0.tgz"
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.3.2.tgz"
         },
         "body-parser": {
           "version": "1.0.2",
-          "from": "body-parser@~1.0.0",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.0.2.tgz",
           "dependencies": {
-            "type-is": {
-              "version": "1.1.0",
-              "from": "type-is@~1.1.0",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.1.0.tgz",
-              "dependencies": {
-                "mime": {
-                  "version": "1.2.11",
-                  "from": "mime@~1.2.11",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                }
-              }
+            "qs": {
+              "version": "0.6.6",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
             },
             "raw-body": {
               "version": "1.1.7",
-              "from": "raw-body@~1.1.2",
               "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
               "dependencies": {
                 "bytes": {
                   "version": "1.0.0",
-                  "from": "bytes@1",
                   "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
                 },
                 "string_decoder": {
-                  "version": "0.10.25-1",
-                  "from": "string_decoder@0.10",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 }
               }
             },
-            "qs": {
-              "version": "0.6.6",
-              "from": "qs@~0.6.6",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+            "type-is": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.1.0.tgz",
+              "dependencies": {
+                "mime": {
+                  "version": "1.2.11",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                }
+              }
             }
           }
         },
         "bristol": {
           "version": "0.2.2",
-          "from": "bristol@~0.2.2",
           "resolved": "https://registry.npmjs.org/bristol/-/bristol-0.2.2.tgz",
           "dependencies": {
             "moment": {
               "version": "2.5.1",
-              "from": "moment@~2.5.1",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.5.1.tgz"
             }
           }
         },
+        "chai": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-1.9.1.tgz",
+          "dependencies": {
+            "assertion-error": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
+            },
+            "deep-eql": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+              "dependencies": {
+                "type-detect": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "chai-as-promised": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-4.1.1.tgz"
+        },
+        "chai-properties": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/chai-properties/-/chai-properties-1.1.0.tgz"
+        },
         "commander": {
           "version": "2.3.0",
-          "from": "commander@^2.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
         "cors": {
           "version": "2.3.2",
-          "from": "cors@~2.3.1",
           "resolved": "https://registry.npmjs.org/cors/-/cors-2.3.2.tgz"
         },
         "db-migrate": {
           "version": "0.6.4",
-          "from": "db-migrate@~0.6.4",
           "resolved": "https://registry.npmjs.org/db-migrate/-/db-migrate-0.6.4.tgz",
           "dependencies": {
-            "optimist": {
-              "version": "0.3.7",
-              "from": "optimist@~0.3.0",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "from": "wordwrap@~0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                }
-              }
-            },
             "async": {
               "version": "0.1.22",
-              "from": "async@~0.1.15",
               "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
-            },
-            "semver": {
-              "version": "1.0.14",
-              "from": "semver@~1.0.14",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-1.0.14.tgz"
             },
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@~0.3.4",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             },
             "moment": {
               "version": "1.7.2",
-              "from": "moment@~1.7.2",
               "resolved": "https://registry.npmjs.org/moment/-/moment-1.7.2.tgz"
             },
-            "pkginfo": {
-              "version": "0.3.0",
-              "from": "pkginfo@~0.3.0",
-              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+            "optimist": {
+              "version": "0.3.7",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
             },
             "parse-database-url": {
               "version": "0.2.0",
-              "from": "parse-database-url@~0.2.0",
               "resolved": "https://registry.npmjs.org/parse-database-url/-/parse-database-url-0.2.0.tgz"
+            },
+            "pkginfo": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+            },
+            "semver": {
+              "version": "1.0.14",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-1.0.14.tgz"
             }
           }
         },
         "express": {
-          "version": "4.8.3",
-          "from": "express@^4.4.5",
-          "resolved": "https://registry.npmjs.org/express/-/express-4.8.3.tgz",
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.9.5.tgz",
           "dependencies": {
             "accepts": {
-              "version": "1.0.7",
-              "from": "accepts@~1.0.0",
-              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.0.tgz",
               "dependencies": {
                 "mime-types": {
-                  "version": "1.0.2",
-                  "from": "mime-types@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.1.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.0.3.tgz"
+                    }
+                  }
                 },
                 "negotiator": {
                   "version": "0.4.7",
-                  "from": "negotiator@0.4.7",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
                 }
               }
             },
-            "buffer-crc32": {
-              "version": "0.2.3",
-              "from": "buffer-crc32@0.2.3",
-              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz"
+            "cookie": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
             },
             "debug": {
-              "version": "1.0.4",
-              "from": "debug@*",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "depd": {
-              "version": "0.4.4",
-              "from": "depd@0.4.4",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.4.tgz"
+              "version": "0.4.5",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
             },
             "escape-html": {
               "version": "1.0.1",
-              "from": "escape-html@~1.0.1",
               "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
             },
+            "etag": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
+              "dependencies": {
+                "crc": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+                }
+              }
+            },
             "finalhandler": {
-              "version": "0.1.0",
-              "from": "finalhandler@0.1.0",
-              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.1.0.tgz"
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz"
+            },
+            "fresh": {
+              "version": "0.2.4",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
             },
             "media-typer": {
-              "version": "0.2.0",
-              "from": "media-typer@0.2.0",
-              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz"
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+            },
+            "merge-descriptors": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
             },
             "methods": {
               "version": "1.1.0",
-              "from": "methods@1.1.0",
               "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
+            },
+            "on-finished": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                }
+              }
             },
             "parseurl": {
               "version": "1.3.0",
-              "from": "parseurl@~1.3.0",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
             },
             "path-to-regexp": {
               "version": "0.1.3",
-              "from": "path-to-regexp@0.1.3",
               "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
             },
             "proxy-addr": {
-              "version": "1.0.1",
-              "from": "proxy-addr@1.0.1",
-              "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.3.tgz",
               "dependencies": {
+                "forwarded": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+                },
                 "ipaddr.js": {
-                  "version": "0.1.2",
-                  "from": "ipaddr.js@0.1.2",
-                  "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz"
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.3.tgz"
                 }
               }
             },
             "qs": {
-              "version": "1.2.1",
-              "from": "qs@1.2.1",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.1.tgz"
+              "version": "2.2.4",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz"
             },
             "range-parser": {
-              "version": "1.0.0",
-              "from": "range-parser@1.0.0",
-              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
             },
             "send": {
-              "version": "0.8.1",
-              "from": "send@0.8.1",
-              "resolved": "https://registry.npmjs.org/send/-/send-0.8.1.tgz",
+              "version": "0.9.3",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.9.3.tgz",
               "dependencies": {
-                "finished": {
-                  "version": "1.2.2",
-                  "from": "finished@1.2.2",
-                  "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
-                  "dependencies": {
-                    "ee-first": {
-                      "version": "1.0.3",
-                      "from": "ee-first@1.0.3",
-                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
-                    }
-                  }
+                "destroy": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@1.2.11",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "serve-static": {
-              "version": "1.5.1",
-              "from": "serve-static@~1.5.1",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.1.tgz"
+              "version": "1.6.3",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.3.tgz"
             },
             "type-is": {
-              "version": "1.3.2",
-              "from": "type-is@~1.3.1",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.3.2.tgz",
+              "version": "1.5.1",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.1.tgz",
               "dependencies": {
                 "mime-types": {
-                  "version": "1.0.2",
-                  "from": "mime-types@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.1.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.0.3.tgz"
+                    }
+                  }
                 }
               }
             },
-            "vary": {
-              "version": "0.1.0",
-              "from": "vary@0.1.0",
-              "resolved": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz"
-            },
-            "cookie": {
-              "version": "0.1.2",
-              "from": "cookie@0.1.2",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
-            },
-            "fresh": {
-              "version": "0.2.2",
-              "from": "fresh@0.2.2",
-              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
-            },
-            "cookie-signature": {
-              "version": "1.0.4",
-              "from": "cookie-signature@1.0.4",
-              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
-            },
-            "merge-descriptors": {
-              "version": "0.0.2",
-              "from": "merge-descriptors@0.0.2",
-              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
-            },
             "utils-merge": {
               "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
               "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            },
+            "vary": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
             }
           }
         },
         "glob": {
-          "version": "4.0.5",
-          "from": "glob@^4.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.5.tgz",
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
           "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+            },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "minimatch@^1.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "once": {
-              "version": "1.3.0",
-              "from": "once@^1.3.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.0.tgz"
-            },
-            "graceful-fs": {
-              "version": "3.0.2",
-              "from": "graceful-fs@^3.0.2",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
             }
           }
         },
-        "kexec": {
-          "version": "0.2.0",
-          "from": "kexec@^0.2.0",
-          "resolved": "https://registry.npmjs.org/kexec/-/kexec-0.2.0.tgz"
-        },
-        "knex": {
-          "version": "0.6.22",
-          "from": "knex@^0.6.20",
-          "resolved": "https://registry.npmjs.org/knex/-/knex-0.6.22.tgz",
+        "gulp-jsdoc": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/gulp-jsdoc/-/gulp-jsdoc-0.1.4.tgz",
           "dependencies": {
-            "minimist": {
-              "version": "0.0.10",
-              "from": "minimist@~0.0.9",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            },
-            "bluebird": {
-              "version": "1.2.4",
-              "from": "bluebird@1.2.x",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz"
-            },
             "chalk": {
               "version": "0.4.0",
-              "from": "chalk@^0.4.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
               "dependencies": {
-                "has-color": {
-                  "version": "0.1.7",
-                  "from": "has-color@~0.1.0",
-                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
-                },
                 "ansi-styles": {
                   "version": "1.0.0",
-                  "from": "ansi-styles@~1.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "has-color": {
+                  "version": "0.1.7",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                 },
                 "strip-ansi": {
                   "version": "0.1.1",
-                  "from": "strip-ansi@~0.1.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                 }
               }
             },
-            "interpret": {
-              "version": "0.3.5",
-              "from": "interpret@^0.3.2",
-              "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.3.5.tgz"
-            },
-            "liftoff": {
-              "version": "0.11.3",
-              "from": "liftoff@^0.11.0",
-              "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-0.11.3.tgz",
+            "gulp-util": {
+              "version": "2.2.20",
+              "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
               "dependencies": {
-                "findup-sync": {
-                  "version": "0.1.3",
-                  "from": "findup-sync@~0.1.2",
-                  "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+                "chalk": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                    }
+                  }
+                },
+                "dateformat": {
+                  "version": "1.0.8",
+                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.8.tgz"
+                },
+                "lodash._reinterpolate": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
+                },
+                "lodash.template": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._escapestringchar": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                    },
+                    "lodash.defaults": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.escape": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._escapehtmlchar": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._htmlescapes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash._reunescapedhtml": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._htmlescapes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.keys": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        },
+                        "lodash._shimkeys": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._objecttypes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash.isobject": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._objecttypes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.templatesettings": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
+                    },
+                    "lodash.values": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+                },
+                "multipipe": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.1.tgz",
+                  "dependencies": {
+                    "duplexer2": {
+                      "version": "0.0.2",
+                      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.32",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.32.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                  }
+                },
+                "vinyl": {
+                  "version": "0.2.3",
+                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+                  "dependencies": {
+                    "clone-stats": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "ink-docstrap": {
+              "version": "0.3.0-0",
+              "resolved": "https://registry.npmjs.org/ink-docstrap/-/ink-docstrap-0.3.0-0.tgz"
+            },
+            "jsdoc": {
+              "version": "3.3.0-alpha5",
+              "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.3.0-alpha5.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.1.22",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+                },
+                "catharsis": {
+                  "version": "0.7.1",
+                  "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.7.1.tgz"
+                },
+                "esprima": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                },
+                "js2xmlparser": {
+                  "version": "0.1.5",
+                  "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-0.1.5.tgz"
+                },
+                "taffydb": {
+                  "version": "2.6.2",
+                  "from": "taffydb@https://github.com/hegemonic/taffydb/tarball/master",
+                  "resolved": "https://github.com/hegemonic/taffydb/tarball/master"
+                },
+                "underscore": {
+                  "version": "1.4.4",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                },
+                "wrench": {
+                  "version": "1.3.9",
+                  "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz"
+                }
+              }
+            },
+            "marked": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.2.tgz"
+            },
+            "taffydb": {
+              "version": "2.7.2",
+              "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.2.tgz"
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+            },
+            "through2": {
+              "version": "0.4.2",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.32",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.32.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "dependencies": {
+                    "object-keys": {
+                      "version": "0.4.0",
+                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "vinyl-fs": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.1.4.tgz",
+              "dependencies": {
+                "glob-stream": {
+                  "version": "3.1.15",
+                  "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.15.tgz",
+                  "dependencies": {
+                    "glob2base": {
+                      "version": "0.0.11",
+                      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.11.tgz"
+                    },
+                    "minimatch": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "ordered-read-streams": {
+                      "version": "0.0.8",
+                      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.0.8.tgz"
+                    },
+                    "through2": {
+                      "version": "0.6.2",
+                      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.2.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.32",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.32.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    },
+                    "unique-stream": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+                    }
+                  }
+                },
+                "glob-watcher": {
+                  "version": "0.0.6",
+                  "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+                  "dependencies": {
+                    "gaze": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+                      "dependencies": {
+                        "globule": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                          "dependencies": {
+                            "glob": {
+                              "version": "3.1.21",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "1.2.3",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                                },
+                                "inherits": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "lodash": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "0.2.14",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                              "dependencies": {
+                                "lru-cache": {
+                                  "version": "2.5.0",
+                                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                                },
+                                "sigmund": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                },
+                "map-stream": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "vinyl": {
+                  "version": "0.2.3",
+                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+                  "dependencies": {
+                    "clone-stats": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "wrench": {
+              "version": "1.5.8",
+              "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz"
+            }
+          }
+        },
+        "gulp-jshint": {
+          "version": "1.8.4",
+          "resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-1.8.4.tgz",
+          "dependencies": {
+            "gulp-util": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.1.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                    }
+                  }
+                },
+                "dateformat": {
+                  "version": "1.0.8",
+                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.8.tgz"
+                },
+                "lodash._reinterpolate": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
+                },
+                "lodash.template": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._escapestringchar": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                    },
+                    "lodash.defaults": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.escape": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._escapehtmlchar": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._htmlescapes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash._reunescapedhtml": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._htmlescapes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.keys": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        },
+                        "lodash._shimkeys": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._objecttypes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash.isobject": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._objecttypes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.templatesettings": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
+                    },
+                    "lodash.values": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
+                },
+                "multipipe": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.1.tgz",
+                  "dependencies": {
+                    "duplexer2": {
+                      "version": "0.0.2",
+                      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "0.6.2",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.32",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.32.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                },
+                "vinyl": {
+                  "version": "0.4.3",
+                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.3.tgz",
+                  "dependencies": {
+                    "clone-stats": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "jshint": {
+              "version": "2.5.6",
+              "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.6.tgz",
+              "dependencies": {
+                "cli": {
+                  "version": "0.6.4",
+                  "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.4.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "3.2.11",
-                      "from": "glob@~3.2.9",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                       "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "minimatch": {
                           "version": "0.3.0",
-                          "from": "minimatch@0.3",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                           "dependencies": {
                             "lru-cache": {
                               "version": "2.5.0",
-                              "from": "lru-cache@2",
                               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.0",
-                              "from": "sigmund@~1.0.0",
                               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                             }
                           }
@@ -437,365 +1081,1243 @@
                     }
                   }
                 },
-                "resolve": {
-                  "version": "0.7.4",
-                  "from": "resolve@~0.7.0",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+                "console-browserify": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                  "dependencies": {
+                    "date-now": {
+                      "version": "0.1.4",
+                      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                    }
+                  }
+                },
+                "exit": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+                },
+                "htmlparser2": {
+                  "version": "3.7.3",
+                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
+                    },
+                    "domhandler": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.0.tgz"
+                    },
+                    "domutils": {
+                      "version": "1.5.0",
+                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
+                    },
+                    "entities": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "shelljs": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.1.tgz"
+                },
+                "underscore": {
+                  "version": "1.6.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "rcloader": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
+              "dependencies": {
+                "rcfinder": {
+                  "version": "0.1.8",
+                  "resolved": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.8.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.32",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.32.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "gulp-load-plugins": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-0.5.3.tgz",
+          "dependencies": {
+            "findup-sync": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "multimatch": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
+              "dependencies": {
+                "array-differ": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
+                },
+                "array-union": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
+                  "dependencies": {
+                    "array-uniq": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "gulp-spawn-mocha": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/gulp-spawn-mocha/-/gulp-spawn-mocha-0.4.1.tgz",
+          "dependencies": {
+            "coveralls": {
+              "version": "2.11.2",
+              "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.2.tgz",
+              "dependencies": {
+                "js-yaml": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.1.tgz",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "0.1.15",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+                      "dependencies": {
+                        "underscore": {
+                          "version": "1.4.4",
+                          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                        },
+                        "underscore.string": {
+                          "version": "2.3.3",
+                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                    }
+                  }
+                },
+                "lcov-parse": {
+                  "version": "0.0.6",
+                  "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.6.tgz"
+                },
+                "log-driver": {
+                  "version": "1.2.4",
+                  "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.4.tgz"
+                },
+                "request": {
+                  "version": "2.40.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+                  "dependencies": {
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "form-data": {
+                      "version": "0.1.4",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "0.9.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                        },
+                        "combined-stream": {
+                          "version": "0.0.5",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "mime": {
+                          "version": "1.2.11",
+                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                        }
+                      }
+                    },
+                    "hawk": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "dependencies": {
+                        "boom": {
+                          "version": "0.4.2",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "hoek": {
+                          "version": "0.9.1",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "0.10.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "assert-plus": {
+                          "version": "0.1.2",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.2",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                        }
+                      }
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.1",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                    },
+                    "qs": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.4",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "0.12.1",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.3.1",
+                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "gulp-util": {
+              "version": "2.2.20",
+              "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                    }
+                  }
+                },
+                "dateformat": {
+                  "version": "1.0.8",
+                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.8.tgz"
+                },
+                "lodash._reinterpolate": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
+                },
+                "lodash.template": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._escapestringchar": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                    },
+                    "lodash.defaults": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.escape": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._escapehtmlchar": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._htmlescapes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash._reunescapedhtml": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._htmlescapes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.keys": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        },
+                        "lodash._shimkeys": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._objecttypes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash.isobject": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._objecttypes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.templatesettings": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
+                    },
+                    "lodash.values": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+                },
+                "multipipe": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.1.tgz",
+                  "dependencies": {
+                    "duplexer2": {
+                      "version": "0.0.2",
+                      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.32",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.32.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                  }
+                },
+                "vinyl": {
+                  "version": "0.2.3",
+                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+                  "dependencies": {
+                    "clone-stats": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "inflection": {
+              "version": "1.4.2",
+              "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.4.2.tgz"
+            },
+            "through": {
+              "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            }
+          }
+        },
+        "istanbul": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.2.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            },
+            "async": {
+              "version": "0.9.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "escodegen": {
+              "version": "1.3.3",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
+                },
+                "estraverse": {
+                  "version": "1.5.1",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+                },
+                "esutils": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.39",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.39.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
+            },
+            "fileset": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "handlebars": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.3.7",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.39",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.39.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.2.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "0.1.15",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+                  "dependencies": {
+                    "underscore": {
+                      "version": "1.4.4",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
+            },
+            "once": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "resolve": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+            },
+            "which": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            }
+          }
+        },
+        "jshint-stylish": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-0.2.0.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "has-color": {
+                  "version": "0.1.7",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                }
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+            }
+          }
+        },
+        "kexec": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/kexec/-/kexec-0.2.0.tgz"
+        },
+        "knex": {
+          "version": "0.6.22",
+          "resolved": "https://registry.npmjs.org/knex/-/knex-0.6.22.tgz",
+          "dependencies": {
+            "bluebird": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz"
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "has-color": {
+                  "version": "0.1.7",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                }
+              }
+            },
+            "generic-pool-redux": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/generic-pool-redux/-/generic-pool-redux-0.1.0.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "interpret": {
+              "version": "0.3.7",
+              "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.3.7.tgz"
+            },
+            "liftoff": {
+              "version": "0.11.3",
+              "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-0.11.3.tgz",
+              "dependencies": {
+                "extend": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
+                },
+                "findup-sync": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "3.2.11",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.5.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 },
                 "minimist": {
                   "version": "0.1.0",
-                  "from": "minimist@~0.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz"
                 },
-                "extend": {
-                  "version": "1.2.1",
-                  "from": "extend@~1.2.1",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
+                "resolve": {
+                  "version": "0.7.4",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 }
               }
             },
             "semver": {
               "version": "2.3.2",
-              "from": "semver@^2.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "tildify": {
               "version": "0.2.0",
-              "from": "tildify@^0.2.0",
               "resolved": "https://registry.npmjs.org/tildify/-/tildify-0.2.0.tgz"
-            },
-            "generic-pool-redux": {
-              "version": "0.1.0",
-              "from": "generic-pool-redux@~0.1.0",
-              "resolved": "https://registry.npmjs.org/generic-pool-redux/-/generic-pool-redux-0.1.0.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@~2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "readable-stream": {
-              "version": "1.1.13-1",
-              "from": "readable-stream@^1.1.12",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.25-1",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
-                }
-              }
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@^2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@^0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
-        "mysql": {
-          "version": "2.4.2",
-          "from": "mysql@^2.2.0",
-          "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.4.2.tgz",
+        "mocha": {
+          "version": "1.21.4",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.21.4.tgz",
           "dependencies": {
-            "bignumber.js": {
-              "version": "1.4.0",
-              "from": "bignumber.js@1.4.0",
-              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.0.tgz"
+            "commander": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
             },
-            "readable-stream": {
-              "version": "1.1.13-1",
-              "from": "readable-stream@~1.1.13",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
+            "debug": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.25-1",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                "ms": {
+                  "version": "0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "diff": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz"
+            },
+            "glob": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "growl": {
+              "version": "1.8.1",
+              "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
+            },
+            "jade": {
+              "version": "0.26.3",
+              "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            }
+          }
+        },
+        "mysql": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.5.1.tgz",
+          "dependencies": {
+            "bignumber.js": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.1.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 }
               }
             },
             "require-all": {
               "version": "0.0.8",
-              "from": "require-all@0.0.8",
               "resolved": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz"
             }
           }
         },
         "nconf": {
           "version": "0.6.9",
-          "from": "nconf@^0.6.9",
           "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.6.9.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.9",
-              "from": "async@0.2.9",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
             },
             "ini": {
-              "version": "1.2.1",
-              "from": "ini@1.x.x",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.2.1.tgz"
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.0.tgz"
             },
             "optimist": {
               "version": "0.6.0",
-              "from": "optimist@0.6.0",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
               "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "from": "wordwrap@~0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@~0.0.1",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             }
           }
         },
         "newrelic": {
-          "version": "1.9.2",
-          "from": "newrelic@^1.9.2",
-          "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-1.9.2.tgz",
+          "version": "1.11.2",
+          "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-1.11.2.tgz",
           "dependencies": {
             "bunyan": {
               "version": "0.14.6",
-              "from": "bunyan@0.14.6",
               "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.14.6.tgz"
             },
             "continuation-local-storage": {
-              "version": "3.1.0",
-              "from": "continuation-local-storage@^3.1.0",
-              "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.0.tgz",
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.1.tgz",
               "dependencies": {
-                "emitter-listener": {
-                  "version": "1.0.1",
-                  "from": "emitter-listener@1.0.1",
-                  "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.0.1.tgz",
-                  "dependencies": {
-                    "shimmer": {
-                      "version": "1.0.0",
-                      "from": "shimmer@1.0.0",
-                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
-                    }
-                  }
-                },
                 "async-listener": {
                   "version": "0.4.7",
-                  "from": "async-listener@0.4.7",
                   "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.4.7.tgz",
                   "dependencies": {
                     "shimmer": {
                       "version": "1.0.0",
-                      "from": "shimmer@1.0.0",
+                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+                    }
+                  }
+                },
+                "emitter-listener": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.0.1.tgz",
+                  "dependencies": {
+                    "shimmer": {
+                      "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
                     }
                   }
                 }
               }
             },
+            "proxying-agent": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/proxying-agent/-/proxying-agent-0.1.5.tgz"
+            },
             "yakaa": {
               "version": "1.0.0",
-              "from": "yakaa@^1.0.0",
               "resolved": "https://registry.npmjs.org/yakaa/-/yakaa-1.0.0.tgz"
             }
           }
         },
         "node-syslog": {
           "version": "1.1.7",
-          "from": "node-syslog@^1.1.7",
           "resolved": "https://registry.npmjs.org/node-syslog/-/node-syslog-1.1.7.tgz"
         },
         "nodemailer": {
           "version": "0.7.1",
-          "from": "nodemailer@^0.7.0",
           "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-0.7.1.tgz",
           "dependencies": {
-            "mailcomposer": {
-              "version": "0.2.12",
-              "from": "mailcomposer@~0.2.10",
-              "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.12.tgz",
-              "dependencies": {
-                "mimelib": {
-                  "version": "0.2.17",
-                  "from": "mimelib@~0.2.15",
-                  "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.17.tgz",
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.8",
-                      "from": "encoding@~0.1.7",
-                      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.8.tgz",
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.4",
-                          "from": "iconv-lite@~0.4.3",
-                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
-                        }
-                      }
-                    },
-                    "addressparser": {
-                      "version": "0.2.1",
-                      "from": "addressparser@~0.2.1",
-                      "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.2.1.tgz"
-                    }
-                  }
-                },
-                "mime": {
-                  "version": "1.2.11",
-                  "from": "mime@1.2.11",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                },
-                "follow-redirects": {
-                  "version": "0.0.3",
-                  "from": "follow-redirects@0.0.3",
-                  "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.3.tgz",
-                  "dependencies": {
-                    "underscore": {
-                      "version": "1.6.0",
-                      "from": "underscore@",
-                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-                    }
-                  }
-                },
-                "dkim-signer": {
-                  "version": "0.1.2",
-                  "from": "dkim-signer@~0.1.1",
-                  "resolved": "https://registry.npmjs.org/dkim-signer/-/dkim-signer-0.1.2.tgz",
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.2.4",
-                      "from": "punycode@~1.2.4",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "simplesmtp": {
-              "version": "0.3.32",
-              "from": "simplesmtp@~0.2 || ~0.3.30",
-              "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.32.tgz",
-              "dependencies": {
-                "rai": {
-                  "version": "0.1.11",
-                  "from": "rai@~0.1.11",
-                  "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.11.tgz"
-                },
-                "xoauth2": {
-                  "version": "0.1.8",
-                  "from": "xoauth2@~0.1.8",
-                  "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz"
-                }
-              }
-            },
-            "directmail": {
-              "version": "0.1.8",
-              "from": "directmail@~0.1.7",
-              "resolved": "https://registry.npmjs.org/directmail/-/directmail-0.1.8.tgz"
-            },
-            "he": {
-              "version": "0.3.6",
-              "from": "he@~0.3.6",
-              "resolved": "https://registry.npmjs.org/he/-/he-0.3.6.tgz"
-            },
-            "public-address": {
-              "version": "0.1.1",
-              "from": "public-address@~0.1.1",
-              "resolved": "https://registry.npmjs.org/public-address/-/public-address-0.1.1.tgz"
-            },
             "aws-sdk": {
               "version": "2.0.5",
-              "from": "aws-sdk@2.0.5",
               "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.5.tgz",
               "dependencies": {
                 "aws-sdk-apis": {
-                  "version": "3.1.5",
-                  "from": "aws-sdk-apis@3.x",
-                  "resolved": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.5.tgz"
+                  "version": "3.1.8",
+                  "resolved": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.8.tgz"
                 },
                 "xml2js": {
                   "version": "0.2.6",
-                  "from": "xml2js@0.2.6",
                   "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
                   "dependencies": {
                     "sax": {
                       "version": "0.4.2",
-                      "from": "sax@0.4.2",
                       "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz"
                     }
                   }
                 },
                 "xmlbuilder": {
                   "version": "0.4.2",
-                  "from": "xmlbuilder@0.4.2",
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
                 }
               }
             },
+            "directmail": {
+              "version": "0.1.8",
+              "resolved": "https://registry.npmjs.org/directmail/-/directmail-0.1.8.tgz"
+            },
+            "he": {
+              "version": "0.3.6",
+              "resolved": "https://registry.npmjs.org/he/-/he-0.3.6.tgz"
+            },
+            "mailcomposer": {
+              "version": "0.2.12",
+              "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.12.tgz",
+              "dependencies": {
+                "dkim-signer": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/dkim-signer/-/dkim-signer-0.1.2.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.2.4",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+                    }
+                  }
+                },
+                "follow-redirects": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.3.tgz",
+                  "dependencies": {
+                    "underscore": {
+                      "version": "1.7.0",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "mimelib": {
+                  "version": "0.2.17",
+                  "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.17.tgz",
+                  "dependencies": {
+                    "addressparser": {
+                      "version": "0.2.1",
+                      "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.2.1.tgz"
+                    },
+                    "encoding": {
+                      "version": "0.1.8",
+                      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.8.tgz",
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.4",
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "public-address": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/public-address/-/public-address-0.1.1.tgz"
+            },
             "readable-stream": {
-              "version": "1.1.13-1",
-              "from": "readable-stream@~1.1.9",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.25-1",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            },
+            "simplesmtp": {
+              "version": "0.3.33",
+              "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.33.tgz",
+              "dependencies": {
+                "rai": {
+                  "version": "0.1.11",
+                  "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.11.tgz"
+                },
+                "xoauth2": {
+                  "version": "0.1.8",
+                  "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz"
                 }
               }
             }
@@ -803,276 +2325,36 @@
         },
         "nodemon": {
           "version": "1.2.1",
-          "from": "nodemon@^1.2.1",
           "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.2.1.tgz",
           "dependencies": {
-            "update-notifier": {
-              "version": "0.1.10",
-              "from": "update-notifier@~0.1.8",
-              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.1.10.tgz",
-              "dependencies": {
-                "chalk": {
-                  "version": "0.4.0",
-                  "from": "chalk@^0.4.0",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-                  "dependencies": {
-                    "has-color": {
-                      "version": "0.1.7",
-                      "from": "has-color@~0.1.0",
-                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
-                    },
-                    "ansi-styles": {
-                      "version": "1.0.0",
-                      "from": "ansi-styles@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
-                    },
-                    "strip-ansi": {
-                      "version": "0.1.1",
-                      "from": "strip-ansi@~0.1.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
-                    }
-                  }
-                },
-                "configstore": {
-                  "version": "0.3.1",
-                  "from": "configstore@^0.3.0",
-                  "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.1.tgz",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "3.0.2",
-                      "from": "graceful-fs@~3.0.1",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
-                    },
-                    "js-yaml": {
-                      "version": "3.0.2",
-                      "from": "js-yaml@~3.0.1",
-                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
-                      "dependencies": {
-                        "argparse": {
-                          "version": "0.1.15",
-                          "from": "argparse@~ 0.1.11",
-                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
-                          "dependencies": {
-                            "underscore": {
-                              "version": "1.4.4",
-                              "from": "underscore@~1.4.3",
-                              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
-                            },
-                            "underscore.string": {
-                              "version": "2.3.3",
-                              "from": "underscore.string@~2.3.1",
-                              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
-                            }
-                          }
-                        },
-                        "esprima": {
-                          "version": "1.0.4",
-                          "from": "esprima@~ 1.0.2",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                        }
-                      }
-                    },
-                    "object-assign": {
-                      "version": "0.3.1",
-                      "from": "object-assign@~0.3.1",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
-                    },
-                    "osenv": {
-                      "version": "0.1.0",
-                      "from": "osenv@~0.1.0",
-                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
-                    },
-                    "uuid": {
-                      "version": "1.4.1",
-                      "from": "uuid@~1.4.1",
-                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
-                    }
-                  }
-                },
-                "request": {
-                  "version": "2.40.0",
-                  "from": "request@^2.36.0",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
-                  "dependencies": {
-                    "qs": {
-                      "version": "1.0.2",
-                      "from": "qs@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.0",
-                      "from": "json-stringify-safe@~5.0.0",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
-                    },
-                    "mime-types": {
-                      "version": "1.0.2",
-                      "from": "mime-types@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                    },
-                    "forever-agent": {
-                      "version": "0.5.2",
-                      "from": "forever-agent@~0.5.0",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-                    },
-                    "node-uuid": {
-                      "version": "1.4.1",
-                      "from": "node-uuid@~1.4.0",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
-                    },
-                    "tough-cookie": {
-                      "version": "0.12.1",
-                      "from": "tough-cookie@>=0.12.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-                      "dependencies": {
-                        "punycode": {
-                          "version": "1.3.1",
-                          "from": "punycode@>=0.2.0",
-                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz"
-                        }
-                      }
-                    },
-                    "form-data": {
-                      "version": "0.1.4",
-                      "from": "form-data@~0.1.0",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-                      "dependencies": {
-                        "combined-stream": {
-                          "version": "0.0.5",
-                          "from": "combined-stream@~0.0.4",
-                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
-                          "dependencies": {
-                            "delayed-stream": {
-                              "version": "0.0.5",
-                              "from": "delayed-stream@0.0.5",
-                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                            }
-                          }
-                        },
-                        "mime": {
-                          "version": "1.2.11",
-                          "from": "mime@~1.2.11",
-                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                        },
-                        "async": {
-                          "version": "0.9.0",
-                          "from": "async@~0.9.0",
-                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                        }
-                      }
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.0",
-                      "from": "tunnel-agent@~0.4.0",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
-                    },
-                    "http-signature": {
-                      "version": "0.10.0",
-                      "from": "http-signature@~0.10.0",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.1.2",
-                          "from": "assert-plus@0.1.2",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
-                        },
-                        "asn1": {
-                          "version": "0.1.11",
-                          "from": "asn1@0.1.11",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                        },
-                        "ctype": {
-                          "version": "0.5.2",
-                          "from": "ctype@0.5.2",
-                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
-                        }
-                      }
-                    },
-                    "oauth-sign": {
-                      "version": "0.3.0",
-                      "from": "oauth-sign@~0.3.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
-                    },
-                    "hawk": {
-                      "version": "1.1.1",
-                      "from": "hawk@1.1.1",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                      "dependencies": {
-                        "hoek": {
-                          "version": "0.9.1",
-                          "from": "hoek@0.9.x",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                        },
-                        "boom": {
-                          "version": "0.4.2",
-                          "from": "boom@0.4.x",
-                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-                        },
-                        "cryptiles": {
-                          "version": "0.2.2",
-                          "from": "cryptiles@0.2.x",
-                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-                        },
-                        "sntp": {
-                          "version": "0.2.4",
-                          "from": "sntp@0.2.x",
-                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                        }
-                      }
-                    },
-                    "aws-sign2": {
-                      "version": "0.5.0",
-                      "from": "aws-sign2@~0.5.0",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-                    },
-                    "stringstream": {
-                      "version": "0.0.4",
-                      "from": "stringstream@~0.0.4",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "2.3.2",
-                  "from": "semver@^2.3.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
-                }
-              }
-            },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@~0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "ps-tree": {
               "version": "0.0.3",
-              "from": "ps-tree@~0.0.3",
               "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
               "dependencies": {
                 "event-stream": {
                   "version": "0.5.3",
-                  "from": "event-stream@~0.5",
                   "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
                   "dependencies": {
                     "optimist": {
                       "version": "0.2.8",
-                      "from": "optimist@0.2",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@>=0.0.1 <0.1.0",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
@@ -1080,637 +2362,412 @@
                   }
                 }
               }
-            }
-          }
-        },
-        "raven": {
-          "version": "0.7.0",
-          "from": "raven@^0.7.0",
-          "resolved": "https://registry.npmjs.org/raven/-/raven-0.7.0.tgz",
-          "dependencies": {
-            "cookie": {
-              "version": "0.1.0",
-              "from": "cookie@0.1.0",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
             },
-            "lsmod": {
-              "version": "0.0.3",
-              "from": "lsmod@~0.0.3",
-              "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-0.0.3.tgz"
-            },
-            "node-uuid": {
-              "version": "1.4.1",
-              "from": "node-uuid@~1.4.1",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
-            },
-            "stack-trace": {
-              "version": "0.0.7",
-              "from": "stack-trace@0.0.7",
-              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.7.tgz"
-            },
-            "connect": {
-              "version": "2.25.5",
-              "from": "connect@*",
-              "resolved": "https://registry.npmjs.org/connect/-/connect-2.25.5.tgz",
+            "update-notifier": {
+              "version": "0.1.10",
+              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.1.10.tgz",
               "dependencies": {
-                "basic-auth-connect": {
-                  "version": "1.0.0",
-                  "from": "basic-auth-connect@1.0.0",
-                  "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
-                },
-                "body-parser": {
-                  "version": "1.6.3",
-                  "from": "body-parser@~1.6.3",
-                  "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.3.tgz",
+                "chalk": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                   "dependencies": {
-                    "iconv-lite": {
-                      "version": "0.4.4",
-                      "from": "iconv-lite@0.4.4",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
-                    },
-                    "raw-body": {
-                      "version": "1.3.0",
-                      "from": "raw-body@1.3.0",
-                      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
-                    }
-                  }
-                },
-                "bytes": {
-                  "version": "1.0.0",
-                  "from": "bytes@1.0.0",
-                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
-                },
-                "cookie": {
-                  "version": "0.1.2",
-                  "from": "cookie@0.1.2",
-                  "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
-                },
-                "cookie-parser": {
-                  "version": "1.3.2",
-                  "from": "cookie-parser@1.3.2",
-                  "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.2.tgz"
-                },
-                "cookie-signature": {
-                  "version": "1.0.4",
-                  "from": "cookie-signature@1.0.4",
-                  "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
-                },
-                "compression": {
-                  "version": "1.0.11",
-                  "from": "compression@~1.0.11",
-                  "resolved": "https://registry.npmjs.org/compression/-/compression-1.0.11.tgz",
-                  "dependencies": {
-                    "accepts": {
-                      "version": "1.0.7",
-                      "from": "accepts@~1.0.4",
-                      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
-                      "dependencies": {
-                        "mime-types": {
-                          "version": "1.0.2",
-                          "from": "mime-types@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                        },
-                        "negotiator": {
-                          "version": "0.4.7",
-                          "from": "negotiator@0.4.7",
-                          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
-                        }
-                      }
-                    },
-                    "compressible": {
-                      "version": "1.1.1",
-                      "from": "compressible@~1.1.1",
-                      "resolved": "https://registry.npmjs.org/compressible/-/compressible-1.1.1.tgz"
-                    },
-                    "vary": {
+                    "ansi-styles": {
                       "version": "1.0.0",
-                      "from": "vary@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                    },
+                    "has-color": {
+                      "version": "0.1.7",
+                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                     }
                   }
                 },
-                "connect-timeout": {
-                  "version": "1.2.2",
-                  "from": "connect-timeout@~1.2.2",
-                  "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.2.2.tgz",
+                "configstore": {
+                  "version": "0.3.1",
+                  "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.1.tgz",
                   "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
-                },
-                "csurf": {
-                  "version": "1.4.0",
-                  "from": "csurf@~1.4.0",
-                  "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.4.0.tgz",
-                  "dependencies": {
-                    "csrf-tokens": {
-                      "version": "2.0.0",
-                      "from": "csrf-tokens@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/csrf-tokens/-/csrf-tokens-2.0.0.tgz",
+                    "graceful-fs": {
+                      "version": "3.0.2",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                    },
+                    "js-yaml": {
+                      "version": "3.0.2",
+                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
                       "dependencies": {
-                        "rndm": {
-                          "version": "1.0.0",
-                          "from": "rndm@1",
-                          "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.0.0.tgz"
-                        },
-                        "scmp": {
-                          "version": "0.0.3",
-                          "from": "scmp@~0.0.3",
-                          "resolved": "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz"
-                        },
-                        "uid-safe": {
-                          "version": "1.0.1",
-                          "from": "uid-safe@1",
-                          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
+                        "argparse": {
+                          "version": "0.1.15",
+                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
                           "dependencies": {
-                            "mz": {
-                              "version": "1.0.0",
-                              "from": "mz@1",
-                              "resolved": "https://registry.npmjs.org/mz/-/mz-1.0.0.tgz"
+                            "underscore": {
+                              "version": "1.4.4",
+                              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                            },
+                            "underscore.string": {
+                              "version": "2.3.3",
+                              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                             }
                           }
                         },
-                        "base64-url": {
-                          "version": "1.0.0",
-                          "from": "base64-url@1",
-                          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "debug": {
-                  "version": "1.0.4",
-                  "from": "debug@1.0.4",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
-                },
-                "depd": {
-                  "version": "0.4.4",
-                  "from": "depd@0.4.4",
-                  "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.4.tgz"
-                },
-                "errorhandler": {
-                  "version": "1.1.1",
-                  "from": "errorhandler@1.1.1",
-                  "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.1.1.tgz",
-                  "dependencies": {
-                    "accepts": {
-                      "version": "1.0.7",
-                      "from": "accepts@~1.0.4",
-                      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
-                      "dependencies": {
-                        "mime-types": {
-                          "version": "1.0.2",
-                          "from": "mime-types@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                        },
-                        "negotiator": {
-                          "version": "0.4.7",
-                          "from": "negotiator@0.4.7",
-                          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
+                        "esprima": {
+                          "version": "1.0.4",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                         }
                       }
                     },
-                    "escape-html": {
-                      "version": "1.0.1",
-                      "from": "escape-html@1.0.1",
-                      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                    "object-assign": {
+                      "version": "0.3.1",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
+                    },
+                    "osenv": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+                    },
+                    "uuid": {
+                      "version": "1.4.2",
+                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz"
                     }
                   }
                 },
-                "express-session": {
-                  "version": "1.7.5",
-                  "from": "express-session@~1.7.5",
-                  "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.7.5.tgz",
+                "request": {
+                  "version": "2.44.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.44.0.tgz",
                   "dependencies": {
-                    "buffer-crc32": {
-                      "version": "0.2.3",
-                      "from": "buffer-crc32@0.2.3",
-                      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz"
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                     },
-                    "uid-safe": {
-                      "version": "1.0.1",
-                      "from": "uid-safe@1.0.1",
-                      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
+                    "bl": {
+                      "version": "0.9.3",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
                       "dependencies": {
-                        "mz": {
-                          "version": "1.0.0",
-                          "from": "mz@1",
-                          "resolved": "https://registry.npmjs.org/mz/-/mz-1.0.0.tgz"
-                        },
-                        "base64-url": {
-                          "version": "1.0.0",
-                          "from": "base64-url@1",
-                          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "utils-merge": {
-                      "version": "1.0.0",
-                      "from": "utils-merge@1.0.0",
-                      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-                    }
-                  }
-                },
-                "finalhandler": {
-                  "version": "0.1.0",
-                  "from": "finalhandler@0.1.0",
-                  "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.1.0.tgz",
-                  "dependencies": {
-                    "escape-html": {
-                      "version": "1.0.1",
-                      "from": "escape-html@1.0.1",
-                      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
-                    }
-                  }
-                },
-                "fresh": {
-                  "version": "0.2.2",
-                  "from": "fresh@0.2.2",
-                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
-                },
-                "media-typer": {
-                  "version": "0.2.0",
-                  "from": "media-typer@0.2.0",
-                  "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz"
-                },
-                "method-override": {
-                  "version": "2.1.3",
-                  "from": "method-override@~2.1.3",
-                  "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.1.3.tgz",
-                  "dependencies": {
-                    "methods": {
-                      "version": "1.1.0",
-                      "from": "methods@1.1.0",
-                      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
-                    },
-                    "vary": {
-                      "version": "1.0.0",
-                      "from": "vary@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
-                    }
-                  }
-                },
-                "morgan": {
-                  "version": "1.2.2",
-                  "from": "morgan@~1.2.2",
-                  "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.2.2.tgz",
-                  "dependencies": {
-                    "basic-auth": {
-                      "version": "1.0.0",
-                      "from": "basic-auth@1.0.0",
-                      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
-                    },
-                    "finished": {
-                      "version": "1.2.2",
-                      "from": "finished@~1.2.2",
-                      "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
-                      "dependencies": {
-                        "ee-first": {
-                          "version": "1.0.3",
-                          "from": "ee-first@1.0.3",
-                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "multiparty": {
-                  "version": "3.3.2",
-                  "from": "multiparty@3.3.2",
-                  "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.13-1",
-                      "from": "readable-stream@~1.1.9",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.25-1",
-                          "from": "string_decoder@~0.10.x",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    },
-                    "stream-counter": {
-                      "version": "0.2.0",
-                      "from": "stream-counter@~0.2.0",
-                      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
-                    }
-                  }
-                },
-                "on-headers": {
-                  "version": "1.0.0",
-                  "from": "on-headers@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
-                },
-                "parseurl": {
-                  "version": "1.3.0",
-                  "from": "parseurl@~1.3.0",
-                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
-                },
-                "qs": {
-                  "version": "1.2.1",
-                  "from": "qs@1.2.1",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.1.tgz"
-                },
-                "response-time": {
-                  "version": "2.0.1",
-                  "from": "response-time@~2.0.1",
-                  "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz"
-                },
-                "serve-favicon": {
-                  "version": "2.0.1",
-                  "from": "serve-favicon@2.0.1",
-                  "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.0.1.tgz"
-                },
-                "serve-index": {
-                  "version": "1.1.6",
-                  "from": "serve-index@~1.1.6",
-                  "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.6.tgz",
-                  "dependencies": {
-                    "accepts": {
-                      "version": "1.0.7",
-                      "from": "accepts@~1.0.7",
-                      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
-                      "dependencies": {
-                        "mime-types": {
-                          "version": "1.0.2",
-                          "from": "mime-types@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                        },
-                        "negotiator": {
-                          "version": "0.4.7",
-                          "from": "negotiator@0.4.7",
-                          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
-                        }
-                      }
-                    },
-                    "batch": {
-                      "version": "0.5.1",
-                      "from": "batch@0.5.1",
-                      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz"
-                    }
-                  }
-                },
-                "serve-static": {
-                  "version": "1.5.1",
-                  "from": "serve-static@~1.5.1",
-                  "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.1.tgz",
-                  "dependencies": {
-                    "escape-html": {
-                      "version": "1.0.1",
-                      "from": "escape-html@1.0.1",
-                      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
-                    },
-                    "send": {
-                      "version": "0.8.1",
-                      "from": "send@0.8.1",
-                      "resolved": "https://registry.npmjs.org/send/-/send-0.8.1.tgz",
-                      "dependencies": {
-                        "finished": {
-                          "version": "1.2.2",
-                          "from": "finished@1.2.2",
-                          "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
+                        "readable-stream": {
+                          "version": "1.0.32",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.32.tgz",
                           "dependencies": {
-                            "ee-first": {
-                              "version": "1.0.3",
-                              "from": "ee-first@1.0.3",
-                              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caseless": {
+                      "version": "0.6.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "form-data": {
+                      "version": "0.1.4",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "0.9.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                        },
+                        "combined-stream": {
+                          "version": "0.0.5",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                             }
                           }
                         },
                         "mime": {
                           "version": "1.2.11",
-                          "from": "mime@1.2.11",
                           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                        },
-                        "ms": {
-                          "version": "0.6.2",
-                          "from": "ms@0.6.2",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                        },
-                        "range-parser": {
-                          "version": "1.0.0",
-                          "from": "range-parser@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
                         }
                       }
                     },
-                    "utils-merge": {
-                      "version": "1.0.0",
-                      "from": "utils-merge@1.0.0",
-                      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-                    }
-                  }
-                },
-                "type-is": {
-                  "version": "1.3.2",
-                  "from": "type-is@~1.3.2",
-                  "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.3.2.tgz",
-                  "dependencies": {
+                    "hawk": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "dependencies": {
+                        "boom": {
+                          "version": "0.4.2",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "hoek": {
+                          "version": "0.9.1",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "0.10.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "assert-plus": {
+                          "version": "0.1.2",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.2",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                        }
+                      }
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                    },
                     "mime-types": {
                       "version": "1.0.2",
-                      "from": "mime-types@~1.0.1",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.1",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.4.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+                    },
+                    "qs": {
+                      "version": "1.2.2",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.4",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "0.12.1",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.3.1",
+                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                     }
                   }
                 },
-                "vhost": {
-                  "version": "2.0.0",
-                  "from": "vhost@2.0.0",
-                  "resolved": "https://registry.npmjs.org/vhost/-/vhost-2.0.0.tgz"
-                },
-                "pause": {
-                  "version": "0.0.1",
-                  "from": "pause@0.0.1",
-                  "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+                "semver": {
+                  "version": "2.3.2",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
                 }
               }
+            }
+          }
+        },
+        "raven": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/raven/-/raven-0.7.2.tgz",
+          "dependencies": {
+            "cookie": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
             },
-            "koa": {
-              "version": "0.10.0",
-              "from": "koa@*",
-              "resolved": "https://registry.npmjs.org/koa/-/koa-0.10.0.tgz",
-              "dependencies": {
-                "escape-html": {
-                  "version": "1.0.1",
-                  "from": "escape-html@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
-                },
-                "statuses": {
-                  "version": "1.0.3",
-                  "from": "statuses@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.0.3.tgz"
-                },
-                "accepts": {
-                  "version": "1.0.7",
-                  "from": "accepts@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
-                  "dependencies": {
-                    "negotiator": {
-                      "version": "0.4.7",
-                      "from": "negotiator@0.4.7",
-                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
-                    }
-                  }
-                },
-                "type-is": {
-                  "version": "1.3.2",
-                  "from": "type-is@~1.3.1",
-                  "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.3.2.tgz"
-                },
-                "mime-types": {
-                  "version": "1.0.2",
-                  "from": "mime-types@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                },
-                "media-typer": {
-                  "version": "0.2.0",
-                  "from": "media-typer@~0.2.0",
-                  "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz"
-                },
-                "finished": {
-                  "version": "1.2.2",
-                  "from": "finished@1.2.2",
-                  "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
-                  "dependencies": {
-                    "ee-first": {
-                      "version": "1.0.3",
-                      "from": "ee-first@1.0.3",
-                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
-                    }
-                  }
-                },
-                "co": {
-                  "version": "3.1.0",
-                  "from": "co@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
-                },
-                "debug": {
-                  "version": "1.0.4",
-                  "from": "debug@*",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
-                },
-                "fresh": {
-                  "version": "0.2.2",
-                  "from": "fresh@~0.2.1",
-                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
-                },
-                "koa-compose": {
-                  "version": "2.3.0",
-                  "from": "koa-compose@~2.3.0",
-                  "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-2.3.0.tgz"
-                },
-                "koa-is-json": {
-                  "version": "1.0.0",
-                  "from": "koa-is-json@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz"
-                },
-                "cookies": {
-                  "version": "0.5.0",
-                  "from": "cookies@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.5.0.tgz",
-                  "dependencies": {
-                    "keygrip": {
-                      "version": "1.0.1",
-                      "from": "keygrip@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.1.tgz"
-                    }
-                  }
-                },
-                "delegates": {
-                  "version": "0.0.3",
-                  "from": "delegates@0.0.3",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.0.3.tgz"
-                },
-                "dethroy": {
-                  "version": "1.0.1",
-                  "from": "dethroy@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/dethroy/-/dethroy-1.0.1.tgz"
-                },
-                "error-inject": {
-                  "version": "1.0.0",
-                  "from": "error-inject@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz"
-                },
-                "vary": {
-                  "version": "0.1.0",
-                  "from": "vary@~0.1.0",
-                  "resolved": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz"
-                },
-                "parseurl": {
-                  "version": "1.2.0",
-                  "from": "parseurl@~1.2.0",
-                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.2.0.tgz"
-                },
-                "only": {
-                  "version": "0.0.2",
-                  "from": "only@0.0.2",
-                  "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz"
-                }
-              }
+            "lsmod": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-0.0.3.tgz"
+            },
+            "node-uuid": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+            },
+            "stack-trace": {
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.7.tgz"
             }
           }
         },
         "redis": {
           "version": "0.10.3",
-          "from": "redis@^0.10.3",
           "resolved": "https://registry.npmjs.org/redis/-/redis-0.10.3.tgz"
         },
         "sequencify": {
           "version": "0.0.7",
-          "from": "sequencify@0.0.7",
           "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
+        },
+        "sinon": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.10.3.tgz",
+          "dependencies": {
+            "formatio": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.0.2.tgz",
+              "dependencies": {
+                "samsam": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.1.tgz"
+                }
+              }
+            },
+            "util": {
+              "version": "0.10.3",
+              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            }
+          }
         },
         "split": {
           "version": "0.3.0",
-          "from": "split@^0.3.0",
           "resolved": "https://registry.npmjs.org/split/-/split-0.3.0.tgz",
           "dependencies": {
             "through": {
-              "version": "2.3.4",
-              "from": "through@2",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.4.tgz"
+              "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             }
           }
         },
         "strip-json-comments": {
           "version": "0.1.3",
-          "from": "strip-json-comments@^0.1.3",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+        },
+        "supertest": {
+          "version": "0.13.0",
+          "resolved": "https://registry.npmjs.org/supertest/-/supertest-0.13.0.tgz",
+          "dependencies": {
+            "methods": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.0.tgz"
+            },
+            "superagent": {
+              "version": "0.18.0",
+              "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.18.0.tgz",
+              "dependencies": {
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
+                "cookiejar": {
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.2.tgz"
+                },
+                "debug": {
+                  "version": "0.7.4",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "extend": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
+                },
+                "form-data": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    }
+                  }
+                },
+                "formidable": {
+                  "version": "1.0.14",
+                  "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+                },
+                "methods": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
+                },
+                "mime": {
+                  "version": "1.2.5",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz"
+                },
+                "qs": {
+                  "version": "0.6.6",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.0.27-1",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                },
+                "reduce-component": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "supertest-as-promised": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/supertest-as-promised/-/supertest-as-promised-1.0.0.tgz",
+          "dependencies": {
+            "bluebird": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz"
+            },
+            "methods": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
+            }
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "stex": "git+https://github.com/stellar/stex.git#master"
   },
   "devDependencies": {
-    "gulp": "^3.8.5",
-    "stex-dev": "git+https://github.com/stellar/stex-dev.git#master"
+    "gulp": "^3.8.5"
   }
 }

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,13 +1,10 @@
+var StexDev = require("stex/dev");
 var Stex    = require("stex");
-var hash    = require("../lib/util/hash")
 var Promise = Stex.Promise;
+var hash    = require("../lib/util/hash");
 
-var helpers = module.exports;
-helpers.Stex    = Stex;
-helpers.stexDev = require("stex-dev");
-helpers.expect  = helpers.stexDev.chai.expect;
-
-helpers.stexDev.sinon.init();
+var testHelper  = module.exports;
+testHelper.Stex = Stex;
 
 var clearDb = function() {
   return db.raw("TRUNCATE TABLE wallets");
@@ -38,9 +35,9 @@ var loadFixtures = function() {
     makeWallet({ id:'3', recoveryId:'3', authToken:'3', mainData:'foo3', recoveryData:'foo3', keychainData:'foo3' }),
     makeWallet({ id:'4', authToken:'4', mainData:'foo4', keychainData:'foo4' })
   ]);
-}
+};
 
-helpers.makeString = function(size) {
+testHelper.makeString = function(size) {
   var x = "";
   for(var i = 0; i < size; i++) {
     x += "a";
@@ -57,7 +54,7 @@ beforeEach(function(done) {
 
 before(function(done) {
   require("../lib/app")
-    .init()
+    .init(true)
     .then(function(stex){ 
       stex.activate();
       done(); 

--- a/test/wallets_test.js
+++ b/test/wallets_test.js
@@ -1,16 +1,14 @@
 var helper  = require("./test_helper");
-var request = helper.stexDev.supertest;
-var expect  = helper.expect;
 var wallet  = require("../lib/models/wallet");
 var hash    = require("../lib/util/hash");
 var _       = helper.Stex._;
 
 describe("POST /wallets/show", function() {
   beforeEach(function(done) {
-    this.params = {}
-    this.referer = "https://launch.stellar.org/#login"
+    this.params = {};
+    this.referer = "https://launch.stellar.org/#login";
     this.submit = function() {
-      return request(app)
+      return test.supertest(app)
         .post('/wallets/show')
         .send(this.params)
         .set("Referer", this.referer)
@@ -227,10 +225,10 @@ describe("POST /wallets/update", function() {
       "mainDataHash":     hash.sha1("mains2"),
       "keychainData":     "keys2",
       "keychainDataHash": hash.sha1("keys2")
-    }
+    };
 
     this.submit = function() {
-      return request(app)
+      return test.supertest(app)
         .post('/wallets/update')
         .send(this.params)
         .set('Accept', 'application/json')
@@ -346,15 +344,15 @@ describe("POST /wallets/replace", function() {
       "newId":        "3",
       "oldAuthToken": "1",
       "newAuthToken": "3"
-    }
+    };
 
     this.submit = function() {
-      return request(app)
+      return test.supertest(app)
         .post('/wallets/replace')
         .send(this.params)
         .set('Accept', 'application/json')
-        .expect('Content-Type', /json/)
-    }
+        .expect('Content-Type', /json/);
+    };
 
     done();
   });
@@ -438,10 +436,10 @@ describe("POST /wallets/replace", function() {
 
 describe("POST /wallets/recover", function() {
   beforeEach(function(done) {
-    this.params = {}
+    this.params = {};
 
     this.submit = function() {
-      return request(app)
+      return test.supertest(app)
         .post('/wallets/recover')
         .send(this.params)
         .set('Accept', 'application/json')
@@ -500,15 +498,15 @@ describe("POST /wallets/create_recovery_data", function() {
       "recoveryId":       "recoveryId",
       "recoveryData":     "foo4",
       "recoveryDataHash": hash.sha1("foo4")
-    }
+    };
 
     this.submit = function() {
-      return request(app)
+      return test.supertest(app)
         .post('/wallets/create_recovery_data')
         .send(this.params)
         .set('Accept', 'application/json')
-        .expect('Content-Type', /json/)
-    }
+        .expect('Content-Type', /json/);
+    };
 
     this.submitWithSuccessTest = function() {
       return this.submit()


### PR DESCRIPTION
So it turns out that having two different projects, stex and stex-dev is a pretty big hassle.  The only reason we split the projects was so that dev dependencies (such as mocha, chai, sinon) aren't part of the runtime dependencies of our built application.  

This PR updates stellar-wallet to use the new unified stex project.
