### PR TITLE
getByWalletId now throws RecordNotFound

### DIFF
--- a/lib/models/wallet-v2.js
+++ b/lib/models/wallet-v2.js
@@ -82,15 +82,19 @@ walletV2.getByWalletId = function(walletId) {
   return db("wallets_v2")
     .where("walletId", walletV2.hashWalletId(walletId))
     .select()
-    .then(_.first);
+    .then(function(results) {
+      var result = _.first(results);
+      if (!result) {
+        throw new errors.RecordNotFound();
+      }
+      return result;
+    });
 };
 
 
 walletV2.getPublicKey = function(walletId) {
   return walletV2.getByWalletId(walletId)
     .then(function (found) {
-      if(!found) { return null; }
-
       return found.publicKey;
     });
 };

--- a/lib/util/signed-json.js
+++ b/lib/util/signed-json.js
@@ -43,6 +43,7 @@ signedJson.middleware = function(req, res, next) {
       next();
     })
     .catch(errors.ArgumentError,              function() { fail("invalid_signature"); })
+    .catch(errors.RecordNotFound,             function() { fail("invalid_signature"); })
     .catch(signedJson.errors.BadSignature,    function() { fail("invalid_signature"); })
     .catch(signedJson.errors.UnparseableBody, function() { fail("malformed_body");    })
     .catch(next);


### PR DESCRIPTION
I propose to change a behavior of `getByWalletId` function: when a wallet is not found it should throw `RecordNotFound` rather then return `null`. When developer forgets to handle this situation by:

``` js
if (!wallet) {
  // ...
}
```

we can be sure that `catch` block will catch it. Right now there are a few places where this function is used but `if (!wallet)` condition is not checked.
