### PR TITLE
Lockout on more actions

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -9,7 +9,7 @@ module.exports = Stex.new(__dirname + "/..", function(stex) {
   var loginFailureTracker = require("./models/login-failure-tracker");
   var refererTracker      = require("./models/referer-tracker");
 
-  router.post('/wallets/show', function(req, res, next) {
+  router.post('/wallets/show', rejectLockedOutIps, function(req, res, next) {
     refererTracker.track(req);
     
     var id = (req.body.id || "").toString();
@@ -23,35 +23,16 @@ module.exports = Stex.new(__dirname + "/..", function(stex) {
       return;
     }
 
-
-    loginFailureTracker.isLoginAllowed(req.ip).then(function(isAllowed) {
-      if(isAllowed) {
-        actuallyLogin();
+    wallet.get(id).then(function(wallet) {
+      if(typeof wallet === "undefined") {
+        failAndRecordLockout(req,res)();
       } else {
-        failSlow();
+        res.send({
+          "status" : "success",
+          "data"   : _.omit(wallet, ['recoveryId', 'recoveryData'])
+        });
       }
     });
-
-    function actuallyLogin() {
-      wallet.get(id).then(function(wallet) {
-        if(typeof wallet === "undefined") {
-          failAndRecordLockout(req,res)();
-        } else {
-          res.send({
-            "status" : "success",
-            "data"   : _.omit(wallet, ['recoveryId', 'recoveryData'])
-          });
-        }
-      });
-    }
-
-    function failSlow() {
-      Promise.delay(loginFailureTracker.SLEEP_TIME).then(fail);
-    }
-
-    function fail() {
-      res.status(404).send({ "status": "fail", "code": "not_found" });
-    }
   });
 
   router.post('/wallets/create', function(req, res, next) {
@@ -94,7 +75,7 @@ module.exports = Stex.new(__dirname + "/..", function(stex) {
       });
   });
 
-  router.post('/wallets/update', function(req, res, next) {
+  router.post('/wallets/update', rejectLockedOutIps, function(req, res, next) {
     var id        = req.body.id;
     var authToken = req.body.authToken;
     var changes   = _.pick(req.body, [
@@ -121,7 +102,7 @@ module.exports = Stex.new(__dirname + "/..", function(stex) {
       });
   });
 
-  router.post('/wallets/replace', function(req, res, next) {
+  router.post('/wallets/replace', rejectLockedOutIps, function(req, res, next) {
     var replaceArgs = _.at(req.body, 'oldId', 'oldAuthToken', 'newId', 'newAuthToken');
 
     wallet.replace.apply(null, replaceArgs)
@@ -134,7 +115,7 @@ module.exports = Stex.new(__dirname + "/..", function(stex) {
       });
   });
 
-  router.post('/wallets/recover', function(req, res, next) {
+  router.post('/wallets/recover', rejectLockedOutIps, function(req, res, next) {
     var recoveryId = req.body.recoveryId;
 
     if (_.isEmpty(recoveryId)) {
@@ -158,7 +139,7 @@ module.exports = Stex.new(__dirname + "/..", function(stex) {
     });
   });
 
-  router.post('/wallets/create_recovery_data', function(req, res, next) {
+  router.post('/wallets/create_recovery_data', rejectLockedOutIps, function(req, res, next) {
     var id        = req.body.id;
     var authToken = req.body.authToken;
     var changes   = _.pick(req.body, [
@@ -192,5 +173,22 @@ module.exports = Stex.new(__dirname + "/..", function(stex) {
         "code":   "not_found"
       });
     };
+  }
+
+  function rejectLockedOutIps(req,res,next) {
+    loginFailureTracker.isLoginAllowed(req.ip).then(function(isAllowed) {
+      if(isAllowed) {
+        next();
+      } else {
+        failSlow();
+      }
+    });
+
+    function failSlow() {
+      Promise.delay(loginFailureTracker.SLEEP_TIME)
+        .then(function() {
+          res.status(404).send({ "status": "fail", "code": "not_found" });
+        });
+    }
   }
 });


### PR DESCRIPTION
This PR adds ip lockout capabilities to any action that uses `walletID` or `recoveryID` as a means of identification.  Given that the two are derived from username/password combo, we cannot allow actions that use them to allow unlimited failures.  Doing so will allow an attacker to confirm whether or not they have guessed the correct password.

This PR introduces:
- a simple middleware to protect the actions:  `rejectLockedOutIps`
- a simple helper to record failures in a uniform way `failAndRecordLockout`
