### PR TITLE
Clear totpDisabledAt properly when resetting the totpKey

### DIFF
--- a/lib/controllers/v2/totp.js
+++ b/lib/controllers/v2/totp.js
@@ -11,7 +11,7 @@ totp.enable =  signedJson.action(function(req, res, next) {
 
   walletV2.getByWalletId(req.verified.walletId)
     .then(function (wallet) {
-      if (wallet.totpKey) {
+      if (walletV2.isTotpEnabled(wallet)) {
         throw new errors.Forbidden();
       }
 

--- a/lib/controllers/v2/wallets.js
+++ b/lib/controllers/v2/wallets.js
@@ -34,7 +34,7 @@ wallets.getLockVersion = signedJson.action(function(req, res, next) {
 
   walletV2.getByWalletId(req.verified.walletId)
     .then(function(wallet) {
-        if (wallet.username != body.username) {
+        if (wallet.username !== body.username) {
           throw new errors.RecordNotFound();
         }
       res.send({lockVersion: wallet.lockVersion});

--- a/lib/models/wallet-v2.js
+++ b/lib/models/wallet-v2.js
@@ -203,7 +203,7 @@ walletV2.enableTotp = function(id, lockVersion, totpKey, totpCode) {
     return Promise.reject(new walletV2.errors.InvalidTotpCode());
   }
 
-  return walletV2.update(id, lockVersion, {totpKey:totpKey});
+  return walletV2.update(id, lockVersion, {totpKey:totpKey, totpDisabledAt:null});
 };
 
 walletV2.disableTotp = function(id, lockVersion, totpKey, totpCode) {

--- a/test/wallets_v2_test.js
+++ b/test/wallets_v2_test.js
@@ -553,6 +553,26 @@ describe("POST /v2/totp/enable", function() {
         done(err);
       });
   });
+
+  it("clears the totpDisabledAt column", function(done) {
+    var self = this;
+
+    return test.supertestAsPromised(app)
+      .post('/v2/totp/enable')
+      .sendSigned(this.params, "mfa-disabled@stellar.org", helper.testKeyPair)
+      .set('Accept', 'application/json')
+      .expect(200)
+      .then(function () {
+        return walletV2.get("mfa-disabled@stellar.org").then(function(w) {
+          expect(w.totpDisabledAt).to.be.null;
+          expect(w.totpKey).to.eq(self.params.totpKey);
+          done();
+        });
+      })
+      .catch(function(err) {
+        done(err);
+      });
+  });
 });
 
 describe("POST /v2/totp/disable", function() {


### PR DESCRIPTION
This PR fixes two bugs (and one lint error):
1.  /v2/totp/enable was not properly using `isTotpEnabled` meaning that you could not reset a disabled totp key
2.  /v2/totp/enable was not clearing totpDisabledAt when setting the new key, meaning that it would be instantly disabled
