### PR TITLE
Cron and grace period emails

### DIFF
--- a/bin/cron.js
+++ b/bin/cron.js
@@ -1,0 +1,47 @@
+// This script should be executed every minute. This is to prevent updating crontab every time
+// we need to add additional script. We're using later.js to check if we should fire a function.
+var Stex      = require('stex');
+var email     = require("../lib/util/email");
+var errors    = Stex.errors;
+var _         = Stex._;
+var Promise   = Stex.Promise;
+var later     = require('later');
+var walletV2  = require("../lib/models/wallet-v2");
+
+var now = new Date();
+now.setSeconds(0); // Round to minutes
+
+require("../lib/app").init()
+  .then(function() {
+    // UTC times
+    // More about text parser: http://bunkat.github.io/later/parsers.html#text
+    var tasks = [
+      run('at 5:00pm everyday', sendGracePeriodEmails)
+    ];
+    return Promise.all(tasks);
+  })
+  .finally(function() {
+    if (stex) {
+      stex.shutdown();
+    }
+  });
+
+function run(when, func) {
+  var schedule = later.parse.text(when);
+  if (later.schedule(schedule).isValid(now)) {
+    return func();
+  }
+  return Promise.resolve();
+}
+
+function sendGracePeriodEmails() {
+  return walletV2.getWithTotpGracePeriodInitiated('1d')
+    .then(function(results) {
+      var emailPromises = _.map(results, function(result) {
+        var usernameWithoutDomain = stex.fbgive.usernameWithoutDomain(result.username);
+        return email.sendEmail(usernameWithoutDomain, 'totp_grace_period');
+      });
+
+      return Promise.all(emailPromises);
+    });
+}

--- a/lib/models/wallet-v2.js
+++ b/lib/models/wallet-v2.js
@@ -242,6 +242,16 @@ walletV2.initiateTotpGracePeriod = function(id) {
     });
 };
 
+walletV2.getWithTotpGracePeriodInitiated = function(durationAgo) {
+  var now       = (new Date()).getTime();
+  var period    = new Duration(durationAgo);
+  var disableAt = new Date(now - period);
+
+  return db("wallets_v2")
+    .whereRaw("DATE(totpDisabledAt) = DATE(?)", disableAt)
+    .select();
+};
+
 walletV2.clearTotpRemovalRequestIfPossible = function(wallet) {
   if(!wallet.totpDisabledAt) {
     return Promise.resolve();

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "duration-js": "^3.3.4",
     "ed25519": "0.0.2",
+    "later": "1.1.6",
     "notp": "^2.0.2",
     "scmp": "0.0.3",
     "scrypt-hash": "^1.1.8",


### PR DESCRIPTION
This PR adds ability to send periodic emails to users with initialized TOTP grace period. But it also introduces support for running other time-based scripts. `cron.js` should be executed every minute using cron (`* * * * *`). We're checking if a specific function has to be run inside a script. It's to prevent updating crontab every time we need to add a new job. We're using [later.js](https://github.com/bunkat/later) to check if we should fire a function.

PS. Adding some tests for `walletV2.getWithTotpGracePeriodInitiated` would be a good idea.
PS2. @nullstyle, it would be great to be able to extend [stex](https://github.com/stellar/stex/blob/master/bin/stex) with additional commands. It could be injectable like initializers. Then we could avoid writing code that initializes stex and run it like: `stex cron`. But that's just a sidenote for the future.
