### PR TITLE
Fixed usernameProof to support other deployments

### DIFF
--- a/lib/models/wallet-v2.js
+++ b/lib/models/wallet-v2.js
@@ -145,7 +145,7 @@ walletV2.create = function(attrs) {
           return Promise.reject(e);
         });
     }).tap(function(attrs) {
-      if (!attrs.usernameProof.migrated) {
+      if (!(attrs.usernameProof && attrs.usernameProof.migrated)) {
         return;
       }
 


### PR DESCRIPTION
It fixes:

```
Cannot read property 'migrated' of undefined
```

when `usernameProof` is not passed.
