### PR TITLE
Remove totpKey during successful login after TOTP grace period (fix #62)

### DIFF
--- a/lib/models/wallet-v2.js
+++ b/lib/models/wallet-v2.js
@@ -262,11 +262,26 @@ walletV2.clearTotpRemovalRequestIfPossible = function(wallet) {
   if(!wallet.totpDisabledAt) {
     return Promise.resolve();
   } else {
-    // set the totpDisabledAt to null
+    var now        = Math.floor((new Date()).getTime() / 1000);
+    var disabledAt = Math.floor(wallet.totpDisabledAt.getTime() / 1000);
+    var updateData;
+    if (disabledAt > now) {
+      // User logged in with a TOTP code => set the totpDisabledAt to null
+      updateData = {
+        totpDisabledAt: null
+      };
+    } else {
+      // User logged in after the TOTP grace period (without a TOTP code)=> clear totpKey too
+      updateData = {
+        totpDisabledAt: null,
+        totpKey: null
+      };
+    }
+
     return db("wallets_v2")
-          .where({id:wallet.id})
-          .whereNull("deletedAt")
-          .update({totpDisabledAt: null});  
+      .where({id:wallet.id})
+      .whereNull("deletedAt")
+      .update(updateData);
   }
 };
 

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -68,6 +68,9 @@ var makeWalletV2 = function(params) {
 };
 
 var loadFixtures = function() {
+  var now               = new Date();
+  var tenMinutesFromNow = new Date((new Date()).getTime() + (1000 * 60 * 10));
+
   return Promise.all([
     makeWallet({ id:'1', recoveryId:'1', authToken:'1', mainData:'foo', recoveryData:'foo', keychainData:'foo' }),
     makeWallet({ id:'3', recoveryId:'3', authToken:'3', mainData:'foo3', recoveryData:'foo3', keychainData:'foo3' }),
@@ -77,7 +80,8 @@ var loadFixtures = function() {
     makeWalletV2({username: "scott@stellar.org", mainData:'foo', keychainData:'foo'}),
     makeWalletV2({username: "david@stellar.org", mainData:'foo', keychainData:'foo'}),
     makeWalletV2({username: "mfa@stellar.org",   mainData:'foo', keychainData:'foo', totpKey:new Buffer('mytotpKey').toString("base64")}),
-    makeWalletV2({username: "mfa-disabled@stellar.org",   mainData:'foo', keychainData:'foo', totpKey:new Buffer('mytotpKey').toString("base64"), totpDisabledAt:new Date()}),
+    makeWalletV2({username: "mfa-disabled@stellar.org",   mainData:'foo', keychainData:'foo', totpKey:new Buffer('mytotpKey').toString("base64"), totpDisabledAt:now}),
+    makeWalletV2({username: "mfa-disabling@stellar.org",   mainData:'foo', keychainData:'foo', totpKey:new Buffer('mytotpKey').toString("base64"), totpDisabledAt:tenMinutesFromNow}),
   ]);
 };
 

--- a/test/wallets_v2_test.js
+++ b/test/wallets_v2_test.js
@@ -82,6 +82,33 @@ describe("POST /v2/wallets/show", function() {
         .expect('Content-Type', /json/);
     };
 
+    this.submitTotpEnable = function() {
+      return test.supertestAsPromised(app)
+        .post('/v2/totp/enable')
+        .sendSigned({
+          "lockVersion": 0,
+          "totpKey": new Buffer("hello").toString("base64"),
+          "totpCode": notp.totp.gen("hello", {})
+        }, "scott@stellar.org", "scott@stellar.org", helper.testKeyPair)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expectBody({status: "success"});
+    };
+
+    this.submitDisableLostDevice = function() {
+      return test.supertestAsPromised(app)
+        .post('/v2/totp/disable_lost_device')
+        .send({
+          username: "scott@stellar.org",
+          walletId: new Buffer("scott@stellar.org").toString("base64")
+        })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expectBody({status: "success"});
+    };
+
     this.lockout = function(username) {
       return Promise.all([
         this.submit({username:username, walletId:"somewrongtoken"}).expect(403),
@@ -132,6 +159,65 @@ describe("POST /v2/wallets/show", function() {
 
   it("succeeds when the totpToken is disabled", function() {
     return this.submit({username:"mfa-disabled@stellar.org", walletId:new Buffer("mfa-disabled@stellar.org").toString("base64")}).expect(200);
+  });
+
+  it("resets the totpKey and totpDisabled after the grace period has elapsed", function(done) {
+    var self = this;
+    var clock = this.sinon.useFakeTimers((new Date()).getTime());
+    var Duration = require("duration-js");
+    return this.submitTotpEnable()
+      .then(function () {
+        return self.submitDisableLostDevice();
+      })
+      .then(function() {
+        clock.tick((new Duration("7d")) + 600);
+        return self.submit({
+            username: "scott@stellar.org",
+            walletId: new Buffer("scott@stellar.org").toString("base64")
+          })
+          .expect(200);
+      })
+      .then(function() {
+        // Check if user is able to get the wallet again.
+        // (https://github.com/stellar/stellar-wallet/issues/62)
+        return self.submit({
+            username: "scott@stellar.org",
+            walletId: new Buffer("scott@stellar.org").toString("base64")
+          })
+          .expect(200);
+      })
+      .then(function() {
+        return walletV2.get("scott@stellar.org").then(function (wallet) {
+          expect(wallet.totpKey).to.be.null;
+          expect(wallet.totpDisabledAt).to.be.null;
+          clock.restore();
+          done();
+        });
+      });
+  });
+
+  it("resets the totpDisabled but leaves totpKey in place before the grace period has elapsed", function(done) {
+    var self = this;
+    return this.submitTotpEnable()
+      .then(function () {
+        return self.submitDisableLostDevice();
+      })
+      .then(function() {
+        var code = notp.totp.gen("hello");
+        return self.submit({
+            username: "scott@stellar.org",
+            walletId: new Buffer("scott@stellar.org").toString("base64"),
+            totpCode: code
+          })
+          .expect(200);
+      })
+      .then(function() {
+        return walletV2.get("scott@stellar.org").then(function (wallet) {
+          expect(wallet.totpKey).to.exist;
+          expect(wallet.totpDisabledAt).to.be.null;
+          done();
+        });
+      });
   });
 });
 
@@ -736,14 +822,6 @@ describe("POST /v2/totp/disable_lost_device", function() {
         .expect('Content-Type', /json/);
     };
 
-    this.submitShow = function() {
-      return test.supertestAsPromised(app)
-        .post('/v2/wallets/show')
-        .send(this.params)
-        .set('Accept', 'application/json')
-        .expect('Content-Type', /json/);
-    };
-
     // Enable TOTP before each test
     test.supertestAsPromised(app)
       .post('/v2/totp/enable')
@@ -757,13 +835,6 @@ describe("POST /v2/totp/disable_lost_device", function() {
       .end(function() {
         done();
       });
-
-    this.clock = this.sinon.useFakeTimers((new Date()).getTime());
-  });
-
-  afterEach(function(done) {
-    this.clock.restore();
-    done();
   });
 
   it("sets totpDisabledAt to current time + the grace period", function(done) {
@@ -785,25 +856,6 @@ describe("POST /v2/totp/disable_lost_device", function() {
       })
       .catch(function(err) {
         done(err);
-      });
-  });
-
-  it("returns the wallet after the grace period", function() {
-    var self = this;
-    var Duration = require("duration-js");
-    return this.submit()
-      .expect(200)
-      .expectBody({status: "success"})
-      .then(function () {
-        self.clock.tick((new Duration("7d")) + 600);
-        return self.submitShow()
-          .expect(200);
-      })
-      .then(function() {
-        // Check if user is able to get the wallet again.
-        // (https://github.com/stellar/stellar-wallet/issues/62)
-        return self.submitShow()
-          .expect(200);
       });
   });
 

--- a/test/wallets_v2_test.js
+++ b/test/wallets_v2_test.js
@@ -137,6 +137,7 @@ describe("POST /v2/wallets/show", function() {
   it("resets the totpKey and totpDisabled after the grace period has elapsed", function() {
     var username = "mfa-disabled@stellar.org";
     return this.submit({username:username, walletId:new Buffer(username).toString("base64")})
+      .expect(200)
       .then(function() {
         return walletV2.get(username);
       })
@@ -150,6 +151,7 @@ describe("POST /v2/wallets/show", function() {
   it("resets totpDisabled but leaves totpKey in place before the grace period has elapsed", function() {
     var username = "mfa-disabling@stellar.org";
     return this.submit({username:username, walletId:new Buffer(username).toString("base64"), totpCode:notp.totp.gen("mytotpKey", {})})
+      .expect(200)
       .then(function() {
         return walletV2.get(username);
       })


### PR DESCRIPTION
We were cancelling TOTP grace period after successful login (by setting `totpDisabledAt` to `null`) but we haven't tested logging in **after** TOTP grace period. In this case we should remove `totpKey` from a wallet.