### PR TITLE
Use the same validation as the api on the username

### DIFF
--- a/lib/util/validate.js
+++ b/lib/util/validate.js
@@ -84,27 +84,35 @@ validate.json = function(prop) {
 };
 
 /**
- * A valid username is of the form: user@domain.com.  if it looks like an email
- * it is good enough for us.
+ * Validates the length and character class of an email-like username.
  * 
  * @param {string} prop the name of the prop to validate
  */
 validate.username = function(prop) {
   return function(data) {
-    var value       = data[prop];
-    var validLength = value.length >= 3 && value.length <= 255;
-    var validEmail  = validator.isEmail(value);
+    var value           = data[prop];
+    var parts           = value.split('@');
+    var username        = parts[0];
+    var domain          = parts[1];
+    var validLength     = username.length >= 3 && username.length <= 20;
+    var validCharacters = !!username.match(/^[a-zA-Z0-9]+([._-]+[a-zA-Z0-9]+)*$/);
     
     var e;
     
     if(!validLength) {
-      e = new validate.errors.InvalidUsername(prop + " is not 3-255 characters");
+      e = new validate.errors.InvalidUsername(prop + " is not 3-20 characters");
       e.field = prop;
       return Promise.reject(e);
     }
     
-    if(!validEmail) {
+    if(!validCharacters) {
       e = new validate.errors.InvalidUsername(prop + " contains invalid characters");
+      e.field = prop;
+      return Promise.reject(e);
+    }
+
+    if(!domain) {
+      e = new validate.errors.InvalidUsername(prop + " does not have a domain");
       e.field = prop;
       return Promise.reject(e);
     }

--- a/test/wallets_v2_test.js
+++ b/test/wallets_v2_test.js
@@ -228,7 +228,7 @@ describe("POST /v2/wallets/create", function() {
   });
   
   it("fails when the username is less than 3 characters", function() {
-    this.params.username = "aa";
+    this.params.username = "aa@stellar.org";
     return this.submit()
         .expect(400)
         .expectBody({field:"username", code:"invalid_username"});


### PR DESCRIPTION
Properly validate the username length and fix the test for this.
Validate the username the same way the the API does (length and character structure).
Instead of enforcing email address structure, just require the presence of a domain.

Fixes #64.